### PR TITLE
Fix no artifacts found error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Used together with [action-terraform](https://github.com/Pararius/action-terraform) for auto-approving (and merging) of pull request created by Dependabot
 
+**If the only changes are in `terraform-directory` and this action does not find any artifacts created by `action-terraform` (skipped maybe) it will still approve and merge**
+
 Example usage:
 
 ```yaml
@@ -25,3 +27,4 @@ Example usage:
           terraform-directory: 'terraform/'
           merge: true
 ```
+

--- a/action.yml
+++ b/action.yml
@@ -42,16 +42,16 @@ runs:
       path: summary
   # output true if any state in inputs.terraform-directory changed
   - id: summary
-    if: steps.check.outputs.skip == 'false'
+    if: (success() || failure()) && steps.check.outputs.skip == 'false'
     shell: bash
-    run: (cat summary/terraform.*.summary || echo "No summary files found!" && exit 1) | grep 'true' || echo "has_changes=false" >> $GITHUB_OUTPUT
+    run: (cat summary/terraform.*.summary || true) | grep 'true' || echo "has_changes=false" >> $GITHUB_OUTPUT
   # approve based on summary step ouptput
   - uses: hmarr/auto-approve-action@v3
-    if: steps.summary.outputs.has_changes == 'false'
+    if: (success() || failure()) && steps.summary.outputs.has_changes == 'false'
     with:
       github-token: ${{ inputs.github-token }}
   # merge based on summary step output
-  - if: (inputs.merge || inputs.force-merge) && steps.summary.outputs.has_changes == 'false'
+  - if: (success() || failure()) && (inputs.merge || inputs.force-merge) && steps.summary.outputs.has_changes == 'false'
     run: |
       PR_NUMBER=$(echo "$GITHUB_REF" | cut -d '/' -f3)
       gh pr -R "${GITHUB_REPOSITORY}" merge "${PR_NUMBER}" -s `[[ "$USE_ADMIN" == "true" ]] && echo '--admin' || echo '--auto'`


### PR DESCRIPTION
Attempt to fix situations where previous `action-terraform` jobs are skipped, but there are still changes made to a Terraform file and this action fails because no artifacts were created.

In this situation these changes assume that there are no state changes and will merge the PR.
The user of this action will have to be very careful with its use of the `if` conditions for this job (you don't want `if: always()` in this case for obvious reasons)

An alternative to this would be that the user would be to use a summary step that creates a dummy artifact with false contents and would probably be a safer bet.